### PR TITLE
Fix small typo

### DIFF
--- a/content/modules/ROOT/pages/04-vm-patching.adoc
+++ b/content/modules/ROOT/pages/04-vm-patching.adoc
@@ -92,7 +92,7 @@ To execute the `patch_vm_playbook.yml` within Ansible Automation Platform, creat
 +
 image::patch_vm.png[title='Patch VM', link=self, window=blank]
 +
-This gives a breakdown of all the taks that ran and a play recap of the changes
+This gives a breakdown of all the tasks that ran and a play recap of the changes
 made to the different hosts. If you take a closer look at the `Update
 security-related packages on all hosts` task, you can drill into specific host
 details on what was installed on the system(s).


### PR DESCRIPTION
This change fixes a typo with the work `tasks` that has been spelled as `taks`